### PR TITLE
Add support for consequtive runs

### DIFF
--- a/PuppetManifestGenerator.psm1
+++ b/PuppetManifestGenerator.psm1
@@ -38,22 +38,27 @@ Function Invoke-PuppetGenerator
     [string]$ModulePath = (Join-Path $PSScriptRoot "resources"),
 
     [Alias('Output','Out')]
-    [string]$OutPutPath = (Join-Path $PSScriptRoot "output")
+    [string]$OutPutPath = (Join-Path $PSScriptRoot "output"),
+
+    [switch]$DoNotCleanOutput = $false
   )
 
   $jsonFilePath = Join-Path $OutPutPath "json"
   $manifestFilePath = Join-Path $OutPutPath "manifest"
 
+  if (-not $DoNotCleanOutput) {
+    if (Test-Path($jsonFilePath)) { Remove-Item $jsonFilePath -Force -Recurse -EA SilentlyContinue | Out-Null }
+    if (Test-Path($manifestFilePath)) { Remove-Item $manifestFilePath -Force -Recurse -EA SilentlyContinue | Out-Null }
+  }
   if(-not(Test-path $OutPutPath)){ mkdir $OutPutPath }
-  if (Test-Path($jsonFilePath)) { Remove-Item $jsonFilePath -Force -Recurse -EA SilentlyContinue | Out-Null }
   if(-not(Test-path $jsonFilePath)){ mkdir $jsonFilePath | Out-Null }
-  if (Test-Path($manifestFilePath)) { Remove-Item $manifestFilePath -Force -Recurse -EA SilentlyContinue | Out-Null }
   if(-not(Test-path $manifestFilePath)){ mkdir $manifestFilePath | Out-Null }
 
   Write-Verbose "Creating connections to target nodes"
   $connectionInfo = $PSBoundParameters
   $connectionInfo.Remove('ModulePath') | Out-Null
   $connectionInfo.Remove('OutPutPath') | Out-Null
+  $connectionInfo.Remove('DoNotCleanOutput') | Out-Null
   $connectionInfo.ErrorAction = 'SilentlyContinue'
   $connectionInfo.ErrorVariable = '+connectionErrors'
 

--- a/PuppetManifestGeneratorGUI.psm1
+++ b/PuppetManifestGeneratorGUI.psm1
@@ -61,6 +61,7 @@ function Invoke-PuppetGeneratorGUI {
       (Get-WPFControl 'windowMain' -Window $thisWindow).Cursor = "Wait"
 
       Write-Verbose "Starting the generation..."
+      $SuppressClean = $false
       $targets.SelectNodes("/targets/target") | Group-Object -Property { "$($_.username)`0$($_.password)" } | % {
         $username = ($_.Name -split "`0")[0].Trim()
         $password = ($_.Name -split "`0")[1].Trim()
@@ -73,7 +74,8 @@ function Invoke-PuppetGeneratorGUI {
           $cred = $null
         }
 
-        Invoke-PuppetGenerator -ComputerName $targetList -Credential $cred -OutputPath $outputPath -Verbose:$VerbosePreference
+        Invoke-PuppetGenerator -ComputerName $targetList -Credential $cred -OutputPath $outputPath -Verbose:$VerbosePreference -DoNotCleanOutput:$SuppressClean
+        $SuppressClean = $true
       }
 
       # Enable the window UI..


### PR DESCRIPTION
Added the ability to not clean the output directory prior to execution.  This allows the generator to be run consequtively without destroying previous data
